### PR TITLE
Support running server without CH API keys

### DIFF
--- a/src/main/java/com/frc/codex/discovery/companieshouse/CompaniesHouseClient.java
+++ b/src/main/java/com/frc/codex/discovery/companieshouse/CompaniesHouseClient.java
@@ -13,5 +13,6 @@ public interface CompaniesHouseClient {
 	Company getCompany(String companyNumber) throws JsonProcessingException;
 	List<NewFilingRequest> getCompanyFilings(String companyNumber, String companyName) throws JsonProcessingException;
 	Set<String> getCompanyFilingUrls(String companyNumber, String filingId) throws JsonProcessingException;
+	boolean isEnabled();
 	void streamFilings(Long timepoint, Function<String, Boolean> callback) throws IOException;
 }

--- a/src/main/java/com/frc/codex/discovery/companieshouse/impl/CompaniesHouseConfigImpl.java
+++ b/src/main/java/com/frc/codex/discovery/companieshouse/impl/CompaniesHouseConfigImpl.java
@@ -27,9 +27,9 @@ public class CompaniesHouseConfigImpl implements CompaniesHouseConfig {
 		this.informationApiBaseUrl = Objects.toString(properties.companiesHouseInformationApiBaseUrl(), "");
 		this.rapidRateLimit = properties.companiesHouseRapidRateLimit();
 		this.rapidRateWindow = properties.companiesHouseRapidRateWindow();
-		this.restApiKey = Objects.toString(properties.companiesHouseRestApiKey(), "");
+		this.restApiKey = properties.companiesHouseRestApiKey();
 		this.streamApiBaseUrl = Objects.toString(properties.companiesHouseStreamApiBaseUrl(), "");
-		this.streamApiKey = Objects.toString(properties.companiesHouseStreamApiKey(), "");
+		this.streamApiKey = properties.companiesHouseStreamApiKey();
 	}
 
 	public String documentApiBaseUrl() {

--- a/src/main/java/com/frc/codex/filingindex/controller/AdminController.java
+++ b/src/main/java/com/frc/codex/filingindex/controller/AdminController.java
@@ -129,6 +129,9 @@ public class AdminController extends BaseController {
 		if (!authenticateAdmin(request)) {
 			return new ResponseEntity<>("Unauthorized", HttpStatus.UNAUTHORIZED);
 		}
+		if (!companiesHouseClient.isEnabled()) {
+			return new ResponseEntity<>("Companies House client is disabled", HttpStatus.SERVICE_UNAVAILABLE);
+		}
 		Company company = this.companiesHouseClient.getCompany(companyNumber);
 		model.addAttribute("company", company);
 		List<NewFilingRequest> filings = this.companiesHouseClient.getCompanyFilings(companyNumber, "");

--- a/src/main/java/com/frc/codex/impl/FilingIndexPropertiesImpl.java
+++ b/src/main/java/com/frc/codex/impl/FilingIndexPropertiesImpl.java
@@ -124,14 +124,14 @@ public class FilingIndexPropertiesImpl implements FilingIndexProperties {
 
 		Properties secrets = getSecrets();
 		if (secrets.containsKey(COMPANIES_HOUSE_REST_API_KEY)) {
-			companiesHouseRestApiKey = requireNonNull(secrets.getProperty(COMPANIES_HOUSE_REST_API_KEY));
+			companiesHouseRestApiKey = secrets.getProperty(COMPANIES_HOUSE_REST_API_KEY);
 		} else {
-			companiesHouseRestApiKey = requireNonNull(getEnv(COMPANIES_HOUSE_REST_API_KEY));
+			companiesHouseRestApiKey = getEnv(COMPANIES_HOUSE_REST_API_KEY);
 		}
 		if (secrets.containsKey(COMPANIES_HOUSE_STREAM_API_KEY)) {
-			companiesHouseStreamApiKey = requireNonNull(secrets.getProperty(COMPANIES_HOUSE_STREAM_API_KEY));
+			companiesHouseStreamApiKey = secrets.getProperty(COMPANIES_HOUSE_STREAM_API_KEY);
 		} else {
-			companiesHouseStreamApiKey = requireNonNull(getEnv(COMPANIES_HOUSE_STREAM_API_KEY));
+			companiesHouseStreamApiKey = getEnv(COMPANIES_HOUSE_STREAM_API_KEY);
 		}
 	}
 

--- a/src/main/java/com/frc/codex/indexer/impl/IndexerImpl.java
+++ b/src/main/java/com/frc/codex/indexer/impl/IndexerImpl.java
@@ -198,6 +198,10 @@ public class IndexerImpl implements Indexer {
 	 */
 	@Scheduled(fixedDelay = 60 * 1000)
 	public void indexCompaniesHouseFilings() throws IOException {
+		if (!companiesHouseClient.isEnabled()) {
+			LOG.info("Can not index from Companies House stream. Companies House client is disabled.");
+			return;
+		}
 		if (databaseManager.checkRegistryLimit(RegistryCode.COMPANIES_HOUSE, properties.filingLimitCompaniesHouse())) {
 			return;
 		}
@@ -234,6 +238,10 @@ public class IndexerImpl implements Indexer {
 
 	@Scheduled(fixedDelay = 60 * 1000)
 	public void indexFilingsFromCompaniesIndex() throws JsonProcessingException {
+		if (!companiesHouseClient.isEnabled()) {
+			LOG.info("Can not index filings from companies index: Companies House client is disabled.");
+			return;
+		}
 		LOG.info("Indexing filings from companies index.");
 		List<Company> companies = databaseManager.getIncompleteCompanies(COMPANIES_BATCH_SIZE);
 		LOG.info("Loaded {} incomplete companies from companies index.", companies.size());

--- a/src/test/java/com/frc/codex/discovery/companieshouse/impl/TestCompaniesHouseClientImpl.java
+++ b/src/test/java/com/frc/codex/discovery/companieshouse/impl/TestCompaniesHouseClientImpl.java
@@ -27,6 +27,10 @@ public class TestCompaniesHouseClientImpl implements CompaniesHouseClient {
 		return null;
 	}
 
+	public boolean isEnabled() {
+		return true;
+	}
+
 	public void streamFilings(Long timepoint, Function<String, Boolean> callback) {
 
 	}


### PR DESCRIPTION
#### Reason for change
Running the server without CH API keys causes a lot of failed requests to the CH API.

#### Description of change
Gracefully prevent requests to CH APIs if keys are not configured.

#### Steps to Test
Test locally without CH API keys.

**review**:
@Arelle/arelle
