### PR TITLE
Add ability to seed database with test data after migrations

### DIFF
--- a/dev/sql/seed-database.sql
+++ b/dev/sql/seed-database.sql
@@ -1,0 +1,13 @@
+TRUNCATE filings;
+INSERT INTO filings(
+    discovered_date, status, registry_code, download_url,
+    company_name, company_number, external_filing_id, external_view_url,
+    filing_date, document_date
+)
+VALUES (
+    CURRENT_TIMESTAMP, 'pending', 'CH',
+    'https://find-and-update.company-information.service.gov.uk/company/11162569/filing-history/MzQzOTA3MDIxN2FkaXF6a2N4/document?format=xhtml&download=0',
+    'TUSCANY PIZZA LTD', '11162569', 'MzQzOTA3MDIxN2FkaXF6a2N4',
+    'https://find-and-update.company-information.service.gov.uk/company/11162569/filing-history/MzQzOTA3MDIxN2FkaXF6a2N4/document?format=xhtml&download=0',
+    CURRENT_DATE, CURRENT_DATE
+);

--- a/src/main/java/com/frc/codex/FilingIndexProperties.java
+++ b/src/main/java/com/frc/codex/FilingIndexProperties.java
@@ -15,6 +15,7 @@ public interface FilingIndexProperties {
 	String companiesHouseRestApiKey();
 	String companiesHouseStreamApiBaseUrl();
 	String companiesHouseStreamApiKey();
+	String dbSeedScriptPath();
 	String fcaDataApiBaseUrl();
 	int fcaPastDays();
 	String fcaSearchApiUrl();

--- a/src/main/java/com/frc/codex/impl/FilingIndexPropertiesImpl.java
+++ b/src/main/java/com/frc/codex/impl/FilingIndexPropertiesImpl.java
@@ -33,6 +33,7 @@ public class FilingIndexPropertiesImpl implements FilingIndexProperties {
 	private static final String DB_USERNAME = "DB_USERNAME";
 	private static final String DB_PASSWORD = "DB_PASSWORD";
 	private static final String DB_MAX_LIFETIME = "DB_MAX_LIFETIME";
+	private static final String DB_SEED_SCRIPT_PATH = "DB_SEED_SCRIPT_PATH";
 	private static final String ENABLE_PREPROCESSING = "ENABLE_PREPROCESSING";
 	private static final String FCA_DATA_API_BASE_URL = "FCA_DATA_API_BASE_URL";
 	private static final String FCA_PAST_DAYS = "FCA_PAST_DAYS";
@@ -61,6 +62,7 @@ public class FilingIndexPropertiesImpl implements FilingIndexProperties {
 	private final String dbUsername;
 	private final String dbPassword;
 	private final long dbMaxLifetime;
+	private final String dbSeedScriptPath;
 	private final boolean enablePreprocessing;
 	private final String fcaDataApiBaseUrl;
 	private final int fcaPastDays;
@@ -98,6 +100,7 @@ public class FilingIndexPropertiesImpl implements FilingIndexProperties {
 		dbUsername = requireNonNull(getEnv(DB_USERNAME));
 		dbPassword = requireNonNull(getEnv(DB_PASSWORD));
 		dbMaxLifetime = Long.parseLong(requireNonNull(getEnv(DB_MAX_LIFETIME, "300000")));
+		dbSeedScriptPath = getEnv(DB_SEED_SCRIPT_PATH);
 
 		enablePreprocessing = Boolean.parseBoolean(requireNonNull(getEnv(ENABLE_PREPROCESSING, "false")));
 
@@ -209,6 +212,10 @@ public class FilingIndexPropertiesImpl implements FilingIndexProperties {
 
 	public String companiesHouseStreamApiKey() {
 		return companiesHouseStreamApiKey;
+	}
+
+	public String dbSeedScriptPath() {
+		return dbSeedScriptPath;
 	}
 
 	public boolean enablePreprocessing() {

--- a/src/test/java/com/frc/codex/impl/TestFilingIndexPropertiesImpl.java
+++ b/src/test/java/com/frc/codex/impl/TestFilingIndexPropertiesImpl.java
@@ -58,6 +58,10 @@ public class TestFilingIndexPropertiesImpl implements FilingIndexProperties {
 		return "XXX";
 	}
 
+	public String dbSeedScriptPath() {
+		return null;
+	}
+
 	public boolean enablePreprocessing() {
 		return false;
 	}


### PR DESCRIPTION
#### Description of change
Provide a way to seed the database with consistent data for testing purposes.

#### Steps to Test
Test locally with the following set in your `compose-local.yml`:
```
  frc-codex-server:
    environment:
      DB_SEED_SCRIPT_PATH: "/tmp/sql/seed-database.sql"
    volumes:
      - ./sql:/tmp/sql
```
Verify `TUSCANY PIZZA LTD` filing exists in DB.

**review**:
@Arelle/arelle
