### PR TITLE
Increase company name column length

### DIFF
--- a/src/main/resources/db/migration/V6__company_name_length.sql
+++ b/src/main/resources/db/migration/V6__company_name_length.sql
@@ -1,0 +1,2 @@
+ALTER TABLE filings ALTER COLUMN company_name TYPE VARCHAR(500);
+ALTER TABLE companies ALTER COLUMN company_name TYPE VARCHAR(500);


### PR DESCRIPTION
#### Description of change
The maximum length of `company_name` that we may receive from the CH API is not documented, but it appears live environments have encountered a company with length > 100. Let's increase to 500 to hopefully ensure no further name length issues.

#### Steps to Test
CI

**review**:
@Arelle/arelle
