### PR TITLE
Don't attempt to reconfigure Python logging.

### DIFF
--- a/lambda_function.py
+++ b/lambda_function.py
@@ -8,7 +8,6 @@ from processor.processor import Processor
 from processor.processor_options import ProcessorOptions
 
 logger = logging.getLogger(__name__)
-logging.basicConfig(level=logging.INFO, format='{%(processName)s} [%(levelname)s] %(message)s')
 
 
 def lambda_handler(event, context):

--- a/support/lambda_function.py
+++ b/support/lambda_function.py
@@ -5,7 +5,6 @@ from support.actions.list_errors_action import ListErrorsAction
 from support.actions.reset_filings_action import ResetFilingsAction
 
 logger = logging.getLogger(__name__)
-logging.basicConfig(level=logging.INFO, format='{%(processName)s} [%(levelname)s] %(message)s')
 
 ACTIONS_MAP = {
     'list_errors': ListErrorsAction,


### PR DESCRIPTION
#### Description of change
The AWS Lambda Runtime Interface Client already configures logging, so logging.basicConfig has no effect.  The deployment sets the log level with the AWS_LAMBDA_LOG_LEVEL environment variable.

#### Steps to Test
Deployed.

**review**:
@Arelle/arelle
