### PR TITLE
Adding a result timestamp field to the filings table

### DIFF
--- a/src/main/java/com/frc/codex/database/impl/DatabaseManagerImpl.java
+++ b/src/main/java/com/frc/codex/database/impl/DatabaseManagerImpl.java
@@ -74,7 +74,8 @@ public class DatabaseManagerImpl implements AutoCloseable, DatabaseManager {
 					"upload_time = ?, " +
 					"worker_time = ?, " +
 					"total_processing_time = ?, " +
-					"total_uploaded_bytes = ? " +
+					"total_uploaded_bytes = ?, " +
+					"result_timestamp = CURRENT_TIMESTAMP " +
 					"WHERE filing_id = ?";
 			PreparedStatement statement = connection.prepareStatement(sql);
 			int i = 0;

--- a/src/main/resources/db/migration/V8__generation_timestamp.sql
+++ b/src/main/resources/db/migration/V8__generation_timestamp.sql
@@ -1,0 +1,2 @@
+ALTER TABLE filings
+    ADD COLUMN result_timestamp TIMESTAMPTZ;


### PR DESCRIPTION
#### Description of change

Added a result_timestamp field to the filings table.  

#### Steps to Test

Deploy, generate a viewer, and verify the result_timestamp is populated for that filing in the database.

**review**:
@Arelle/arelle
