### PR TITLE
Update CoHo Filing URL to Download

### DIFF
--- a/src/main/java/com/frc/codex/clients/companieshouse/CompaniesHouseFiling.java
+++ b/src/main/java/com/frc/codex/clients/companieshouse/CompaniesHouseFiling.java
@@ -17,7 +17,7 @@ public record CompaniesHouseFiling(
 	public String downloadUrl() {
 		return "https://find-and-update.company-information.service.gov.uk/company/"
 				+ companyNumber + "/filing-history/" + transactionId
-				+ "/document?format=xhtml&download=0";
+				+ "/document?format=xhtml&download=1";
 	}
 
 }


### PR DESCRIPTION
#### Reason for change
The Filing download link doesn't actually download the filing for CoHo filings.

#### Description of change
Update Filing link for CoHo filings to download HTML instead of opening in browser.

#### Steps to Test
* CI

**review**:
@Arelle/arelle
