### PR TITLE
Use Arelle to Detect Taxonomy Packages and IXDS Files

### DIFF
--- a/processor/base/filing_download_result.py
+++ b/processor/base/filing_download_result.py
@@ -5,5 +5,4 @@ from pathlib import Path
 @dataclass
 class FilingDownloadResult:
     download_path: Path
-    target_path: Path | None
     namelist: list[str]

--- a/processor/main/workers/ixbrl_viewer_worker.py
+++ b/processor/main/workers/ixbrl_viewer_worker.py
@@ -1,7 +1,6 @@
 import datetime
 import logging
 import shutil
-import zipfile
 from dataclasses import dataclass
 from pathlib import Path
 from typing import cast
@@ -46,17 +45,8 @@ class IxbrlViewerWorker(Worker):
             viewer_directory: Path,
             taxonomy_package_urls: list[str],
     ) -> WorkerResult:
-        assert filing_download.target_path is not None
-        packages = list(taxonomy_package_urls)
-        report_path = None
-        for parent in filing_download.target_path.parents:
-            if parent.name == 'reports':
-                report_path = parent
-                continue
-            if report_path and zipfile.is_zipfile(parent):
-                packages.append(str(parent))
-                break
-        result = self._generate_viewer(filing_download.target_path, viewer_directory, packages)
+        assert filing_download.download_path is not None
+        result = self._generate_viewer(filing_download.download_path, viewer_directory, taxonomy_package_urls)
         if not result.success:
             return WorkerResult(
                 job_message.filing_id,

--- a/processor/processor.py
+++ b/processor/processor.py
@@ -39,14 +39,9 @@ class Processor:
 
     def _get_target_path(self, filing_path: Path) -> FilingDownloadResult:
         if not zipfile.is_zipfile(filing_path):
-            return FilingDownloadResult(filing_path, filing_path, [])
-        target_path = None
+            return FilingDownloadResult(filing_path, [])
         with zipfile.ZipFile(filing_path) as zip_file:
-            for file in zip_file.namelist():
-                if file.endswith('.html') or file.endswith('.xhtml'):
-                    target_path = filing_path / file
-                    break
-            return FilingDownloadResult(filing_path, target_path, zip_file.namelist())
+            return FilingDownloadResult(filing_path, zip_file.namelist())
 
     def _handle_message(self, job_message: JobMessage, queue_manager: QueueManager) -> WorkerResult:
         logger.info(
@@ -80,16 +75,7 @@ class Processor:
                 taxonomy_package_urls = self._download_manager.get_package_urls()
                 filing_download_result = self._download_filing(job_message, temp_dir_path)
 
-                if not filing_download_result.target_path:
-                    logger.error(
-                        "Target path could not be determined in filing from %s: (Message: %s, Filing: %s)",
-                        filing_download_result.namelist, job_message.message_id, job_message.filing_id
-                    )
-                    return WorkerResult(
-                        job_message.filing_id,
-                        error=f'Target path could not be determined in filing from {filing_download_result.namelist}.'
-                    )
-                logger.info('Using target path: %s', filing_download_result.target_path)
+                logger.info('Using downloaded filing: %s', filing_download_result.download_path)
                 # Prepare directory for viewer files
 
                 viewer_directory = temp_dir_path / 'viewer'

--- a/processor_tests/test_processor.py
+++ b/processor_tests/test_processor.py
@@ -46,7 +46,7 @@ class TestProcessor(TestCase):
                 success=False,
             ),
         }
-        mock_get_target_path.return_value = FilingDownloadResult(Path('download_url1'), Path('filing.zip'), [])
+        mock_get_target_path.return_value = FilingDownloadResult(Path('download_url1'), [])
         upload_manager = MockUploadManager()
         processor = Processor(
             download_manager=Mock(),


### PR DESCRIPTION
#### Reason for change
Recent updates to Arelle now support report packages, allowing it to:
- Automatically load taxonomy packages from any ZIP file provided as an entry point.
- Discover and load all inline XBRL reports within the ZIP.

#### Description of change
- Updated implementation to pass report ZIP files directly to Arelle as the entry point.

#### Steps to Test
- Confirm that taxonomy details remain accurate and included for FCA filings (taxonomy package).

**review**:
@Arelle/arelle
