### PR TITLE
Setup puppeteer sandbox for ubuntu 24.04

### DIFF
--- a/.github/actions/build_processor/action.yml
+++ b/.github/actions/build_processor/action.yml
@@ -4,7 +4,7 @@ description: Builds the frc-codex-processor Docker image
 runs:
   using: composite
   steps:
-    - uses: actions/setup-python@v5
+    - uses: actions/setup-python@v5.3.0
       with:
         cache: 'pip'
         check-latest: true
@@ -17,9 +17,9 @@ runs:
     - name: Test with tox
       shell: bash
       run: tox
-    - uses: docker/setup-buildx-action@v3
+    - uses: docker/setup-buildx-action@v3.8.0
     - name: Build frc-codex-processor image
-      uses: docker/build-push-action@v6
+      uses: docker/build-push-action@v6.10.0
       with:
         context: .
         file: frc-codex-processor.Dockerfile

--- a/.github/actions/build_server/action.yml
+++ b/.github/actions/build_server/action.yml
@@ -4,9 +4,9 @@ description: Builds the frc-codex-server Docker image
 runs:
   using: composite
   steps:
-    - uses: docker/setup-buildx-action@v3
+    - uses: docker/setup-buildx-action@v3.8.0
     - name: Build frc-codex-server image
-      uses: docker/build-push-action@v6
+      uses: docker/build-push-action@v6.10.0
       with:
         context: .
         file: frc-codex-server.Dockerfile

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -82,7 +82,7 @@ jobs:
           path: ./dev/logs
 
   puppeteer:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -101,6 +101,14 @@ jobs:
       - name: Install dependencies
         shell: bash
         run: npm ci
+      - name: Setup Chromium Sandbox
+        shell: bash
+        run: |
+          cd ~/.cache/puppeteer/chrome/linux-*/chrome-linux64
+          sudo chown root:root chrome_sandbox
+          sudo chmod 4755 chrome_sandbox
+          sudo cp -p chrome_sandbox /usr/local/sbin/chrome-devel-sandbox
+          echo "CHROME_DEVEL_SANDBOX=/usr/local/sbin/chrome-devel-sandbox" >> $GITHUB_ENV
       - name: "Create Dummy Secrets File"
         shell: bash
         run: touch ./frc-codex-server.secrets # Seeded DB does not require secrets

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,8 +13,8 @@ jobs:
   test:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v4.2.2
+      - uses: actions/setup-python@v5.3.0
         with:
           cache: 'pip'
           check-latest: true
@@ -74,7 +74,7 @@ jobs:
           curl -i --fail 'localhost:8082/2015-03-31/functions/function/invocations' \
             --data '{"action":"reset_filings","company_number":"1234567890"}'
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v4.5.0
         if: always()
         with:
           name: docker-logs
@@ -84,8 +84,8 @@ jobs:
   puppeteer:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v4.2.2
+      - uses: actions/setup-python@v5.3.0
         with:
           cache: 'pip'
           check-latest: true
@@ -93,7 +93,7 @@ jobs:
       - name: Install dependencies
         shell: bash
         run: python -m pip install --upgrade pip setuptools wheel
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v4.1.0
         with:
           cache: 'npm'
           check-latest: true
@@ -119,7 +119,7 @@ jobs:
       - name: "Test"
         shell: bash
         run: npm run test
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v4.5.0
         if: failure()
         with:
           name: puppeteer-artifacts

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,43 +37,13 @@ jobs:
         shell: bash
         run: |
           ./dev/env-setup.sh
-      - name: "Test"
+      - name: "Smoke Test"
         # dependabot can not access secrets, which is required for these tests to pass
         # Quick workaround is to not run the tests, but we could implement solutions described here:
         # https://github.com/dependabot/dependabot-core/issues/3253#issuecomment-797125425
         if: ${{ github.actor != 'dependabot[bot]' }}
         shell: bash
-        run: |
-          echo "Testing survey form submission..."
-          curl i --fail -X POST http://localhost:8080/survey \
-            -H "Content-Type: application/x-www-form-urlencoded" \
-            -d "searchUtilityRating=5&searchSpeedRating=4&viewerSpeedRating=3"
-          
-          echo "Wait for smoke testing to be ready..."
-          curl -i --fail --silent http://localhost:8080/admin/smoketest/wait
-          echo "Test invocation"
-          curl -i --fail --silent -L http://localhost:8080/admin/smoketest/invoke
-          echo "Test homepage"
-          curl -i --fail http://localhost:8080/
-          echo "Test CH API client"
-          curl -i --fail http://localhost:8080/admin/smoketest/companieshouse/company/00324341
-          echo "Test CH archive client"
-          curl -i --fail http://localhost:8080/admin/smoketest/companieshouse/history
-          echo "Test FCA API"
-          curl -i --fail http://localhost:8080/admin/smoketest/fca
-          echo "Test indexer page"
-          curl -i --fail http://localhost:8080/admin/smoketest/indexer
-          echo "Test queue page"
-          curl -i --fail http://localhost:8080/admin/smoketest/queue
-          echo "Test database page"
-          curl -i --fail http://localhost:8080/admin/smoketest/database
-          echo "Test support action: list_errors"
-          curl -i --fail 'localhost:8082/2015-03-31/functions/function/invocations' \
-            --data '{"action":"list_errors"}'
-          echo "Test support action: reset_filings"
-          curl -i --fail 'localhost:8082/2015-03-31/functions/function/invocations' \
-            --data '{"action":"reset_filings","company_number":"1234567890"}'
-
+        run: ./dev/smoke-test.sh
       - uses: actions/upload-artifact@v4.5.0
         if: always()
         with:

--- a/dev/smoke-test.sh
+++ b/dev/smoke-test.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-CURL_OPTS="--include --fail"
+CURL_OPTS="--include --fail --connect-timeout 30 --max-time 300"
 
 echo "Testing survey form submission..."
 curl $CURL_OPTS -X POST http://localhost:8080/survey \

--- a/dev/smoke-test.sh
+++ b/dev/smoke-test.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+set -e
+
+CURL_OPTS="--include --fail"
+
+echo "Testing survey form submission..."
+curl $CURL_OPTS -X POST http://localhost:8080/survey \
+  -H "Content-Type: application/x-www-form-urlencoded" \
+  -d "searchUtilityRating=5&searchSpeedRating=4&viewerSpeedRating=3"
+          
+echo "Wait for smoke testing to be ready..."
+curl $CURL_OPTS --silent http://localhost:8080/admin/smoketest/wait
+
+echo "Test invocation"
+curl $CURL_OPTS --silent -L http://localhost:8080/admin/smoketest/invoke
+
+echo "Test homepage"
+curl $CURL_OPTS http://localhost:8080/
+
+echo "Test CH API client"
+curl $CURL_OPTS http://localhost:8080/admin/smoketest/companieshouse/company/00324341
+
+echo "Test CH archive client"
+curl $CURL_OPTS http://localhost:8080/admin/smoketest/companieshouse/history
+
+echo "Test FCA API"
+curl $CURL_OPTS http://localhost:8080/admin/smoketest/fca
+
+echo "Test indexer page"
+curl $CURL_OPTS http://localhost:8080/admin/smoketest/indexer
+
+echo "Test queue page"
+curl $CURL_OPTS http://localhost:8080/admin/smoketest/queue
+
+echo "Test database page"
+curl $CURL_OPTS http://localhost:8080/admin/smoketest/database
+
+echo "Test support action: list_errors"
+curl $CURL_OPTS 'localhost:8082/2015-03-31/functions/function/invocations' \
+  --data '{"action":"list_errors"}'
+
+echo "Test support action: reset_filings"
+curl $CURL_OPTS 'localhost:8082/2015-03-31/functions/function/invocations' \
+  --data '{"action":"reset_filings","company_number":"1234567890"}'


### PR DESCRIPTION
#### Reason for change
Ubuntu latest runners [have started using 24.04](https://github.com/FRC-CODEX/frc-codex/actions/runs/12468473762/job/34799719878?pr=223) which requires setting up a chromium sandbox for puppeteer.

#### Description of change
* Setup sandbox for puppeteer workflow.
* Use specific versions of runner images and actions.

#### Steps to Test
* CI

**review**:
@Arelle/arelle
