### PR TITLE
Add unique constraint to external_filing_id, registry_code

### DIFF
--- a/src/main/java/com/frc/codex/database/impl/DatabaseManagerImpl.java
+++ b/src/main/java/com/frc/codex/database/impl/DatabaseManagerImpl.java
@@ -23,6 +23,7 @@ import java.util.UUID;
 import javax.sql.DataSource;
 
 import org.flywaydb.core.Flyway;
+import org.postgresql.util.PSQLException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.annotation.Profile;
@@ -216,6 +217,12 @@ public class DatabaseManagerImpl implements AutoCloseable, DatabaseManager {
 					throw new SQLException("Creating filing failed, no ID obtained.");
 				}
 			}
+		} catch (PSQLException e) {
+			if (e.getMessage().contains("unique constraint \"filings_registry_code_external_filing_id_idx\"")) {
+				LOG.warn("Filing already exists: {} {}", newFilingRequest.getRegistryCode(), newFilingRequest.getExternalFilingId());
+				return getFilingId(newFilingRequest.getRegistryCode(), newFilingRequest.getExternalFilingId());
+			}
+			throw new RuntimeException(e);
 		} catch (SQLException e) {
 			throw new RuntimeException(e);
 		}

--- a/src/main/java/com/frc/codex/indexer/impl/IndexerImpl.java
+++ b/src/main/java/com/frc/codex/indexer/impl/IndexerImpl.java
@@ -135,7 +135,7 @@ public class IndexerImpl implements Indexer {
 	 * Indexes Companies House filings from captured filing stream events.
 	 * Processes in batches to allow for other tasks to run.
 	 */
-	@Scheduled(initialDelay = 30, fixedDelay = 30, timeUnit = TimeUnit.SECONDS)
+	@Scheduled(initialDelay = 90, fixedDelay = 30, timeUnit = TimeUnit.SECONDS)
 	public void indexCompaniesHouseFilings() throws IOException {
 		Supplier<Boolean> continueCallback = () -> {
 			if (!companiesHouseClient.isEnabled()) {

--- a/src/main/resources/db/migration/V12__unique_external_filing_id.sql
+++ b/src/main/resources/db/migration/V12__unique_external_filing_id.sql
@@ -1,0 +1,3 @@
+DROP INDEX filings_registry_code_external_filing_id_idx;
+-- select filing_id from filings where registry_code = $1 and external_filing_id = $2
+CREATE UNIQUE INDEX filings_registry_code_external_filing_id_idx ON filings (registry_code, external_filing_id) INCLUDE (filing_id);


### PR DESCRIPTION
_Note: I haven't been able to confirm if any duplicates already exist in the production database. We should wait to deploy this until we've either confirmed that no duplicates exist, or until a window where potential downtime would not have a large impact on users._

#### Reason for change
Two instances of the server can briefly be running (and performing indexing on the stream) simultaneously. This could result in duplicate filings being indexed.

#### Description of change
- Add unique index to prevent duplicate filing entries
- Warn on violation of unique index
- Add additional delay before stream indexing to minimize instance overlap

#### Steps to Test
Locally, run two instances of the server simultaneously. Confirm warning eventually appears for duplicate filing entry.

**review**:
@Arelle/arelle
