### PR TITLE
Exclude ixbrl-viewer UI update from dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -31,6 +31,10 @@ updates:
         patterns:
           - "*"
     ignore:
+      - dependency-name: "ixbrl-viewer"
+        update-types:
+          - "version-update:semver-major"
+          - "version-update:semver-minor"
       - dependency-name: "puppeteer-core"
         versions:
           - ">=25"
@@ -48,6 +52,11 @@ updates:
       python-dependencies:
         patterns:
           - "*"
+    ignore:
+      - dependency-name: "ixbrl-viewer"
+        update-types:
+          - "version-update:semver-major"
+          - "version-update:semver-minor"
   - package-ecosystem: "docker"
     cooldown:
       default-days: 1


### PR DESCRIPTION
#### Reason for change

UI update in next ixbrl-viewer minor release will require approval.

#### Description of change

Update dependabot config to ignore minor and major version bumps.

#### Steps to Test

* CI (will fail during UK non-filing hours when coho stream is empty/doesn't have any filings)

**review**:
@Arelle/arelle
