### PR TITLE
Rework `FCA_PAST_DAYS` as an indexing overlap window

### DIFF
--- a/src/main/java/com/frc/codex/clients/fca/impl/FcaClientImpl.java
+++ b/src/main/java/com/frc/codex/clients/fca/impl/FcaClientImpl.java
@@ -55,6 +55,9 @@ public class FcaClientImpl implements FcaClient {
 		ObjectNode node = new ObjectMapper().createObjectNode();
 		node.put("from", this.pageSize * (page - 1));
 		node.put("size", this.pageSize);
+		// Filtering/sorting based on "last_updated_date" would be preferred
+		// since filings are not guaranteed to be added to the index in "submission_date"
+		// order, but attempting to filter by "last_updated_date" yields "Unable to search the data".
 		node.put("sort", "submitted_date");
 		node.put("sortorder", "desc");
 		ObjectNode criteriaObj = node.putObject("criteriaObj");

--- a/src/main/java/com/frc/codex/indexer/impl/IndexerImpl.java
+++ b/src/main/java/com/frc/codex/indexer/impl/IndexerImpl.java
@@ -342,10 +342,16 @@ public class IndexerImpl implements Indexer {
 		if (databaseManager.checkRegistryLimit(RegistryCode.FCA, properties.filingLimitFca())) {
 			return;
 		}
-		LocalDateTime fcaStartDate = properties.fcaPastDays() <= 0 ? null :
-				LocalDateTime.now().minusDays(properties.fcaPastDays());
-		LocalDateTime latestSubmittedDate = databaseManager.getLatestFcaFilingDate(fcaStartDate);
-		List<FcaFiling> filings = fcaClient.fetchAllSinceDate(latestSubmittedDate);
+		LocalDateTime latestSubmittedDate = databaseManager.getLatestFcaFilingDate(LocalDateTime.now());
+		// The sorting/filtering mechanism we use to retrieve the latest FCA filings
+		// attempts to capture all filings sequentially by filtering/sorting by
+		// submission date. Unfortunately, filings are not guaranteed to be added
+		// to the FCA index in submission order, so past entries may be added after a
+		// more recent submission date has already been captured, causing missed filings.
+		// To reduce the likelihood of missed filings (which are most often added only
+		// minutes/hours out of order), add an overlap period on each indexing run.
+		LocalDateTime overlapDate = latestSubmittedDate.minusDays(this.properties.fcaPastDays());
+		List<FcaFiling> filings = fcaClient.fetchAllSinceDate(overlapDate);
 		for (FcaFiling filing : filings) {
 			NewFilingRequest newFilingRequest = NewFilingRequest.builder()
 					.companyName(filing.companyName())


### PR DESCRIPTION
#### Reason for change
Our current FCA indexing process assumes filings are added to the FCA index in `submission_date` order, but that isn't the case. Filings can be added with submission dates earlier than a submission date the indexer has already seen, causing missed filings.

#### Description of change
Filtering/sorting on `last_updated_date` would likely resolve this issue, as it effectively represents the date that the filing was actually added to the index. However, attempting to filter on `last_updated_date` is not supported by the FCA endpoint.

Instead, we can probably capture filings falling into this scenario by simply having the indexer look back further over an overlap window. We already skip filings that already exist so this will not duplicate entries. Examples I've seen would be covered by looking back only 1 day, but a longer overlap period like 30 days doesn't really introduce much cost.

#### Steps to Test
CI
