### PR TITLE
Rework `FCA_PAST_DAYS` as an indexing overlap window

### DIFF
--- a/src/main/java/com/frc/codex/clients/fca/impl/FcaClientImpl.java
+++ b/src/main/java/com/frc/codex/clients/fca/impl/FcaClientImpl.java
@@ -55,6 +55,9 @@ public class FcaClientImpl implements FcaClient {
 		ObjectNode node = new ObjectMapper().createObjectNode();
 		node.put("from", this.pageSize * (page - 1));
 		node.put("size", this.pageSize);
+		// Filtering/sorting based on "last_updated_date" would be preferred
+		// since filings are not guaranteed to be added to the index in "submission_date"
+		// order, but attempting to filter by "last_updated_date" yields "Unable to search the data".
 		node.put("sort", "submitted_date");
 		node.put("sortorder", "desc");
 		ObjectNode criteriaObj = node.putObject("criteriaObj");

--- a/src/main/java/com/frc/codex/clients/fca/impl/FcaClientImpl.java
+++ b/src/main/java/com/frc/codex/clients/fca/impl/FcaClientImpl.java
@@ -59,7 +59,7 @@ public class FcaClientImpl implements FcaClient {
 		// since filings are not guaranteed to be added to the index in "submission_date"
 		// order, but attempting to filter by "last_updated_date" yields "Unable to search the data".
 		node.put("sort", "submitted_date");
-		node.put("sortorder", "desc");
+		node.put("sortorder", "asc");
 		ObjectNode criteriaObj = node.putObject("criteriaObj");
 		ObjectNode criteria = criteriaObj.putArray("criteria").addObject();
 		criteria.put("name", "tag_esef");

--- a/src/main/java/com/frc/codex/indexer/impl/IndexerImpl.java
+++ b/src/main/java/com/frc/codex/indexer/impl/IndexerImpl.java
@@ -342,10 +342,16 @@ public class IndexerImpl implements Indexer {
 		if (databaseManager.checkRegistryLimit(RegistryCode.FCA, properties.filingLimitFca())) {
 			return;
 		}
-		LocalDateTime fcaStartDate = properties.fcaPastDays() <= 0 ? null :
-				LocalDateTime.now().minusDays(properties.fcaPastDays());
-		LocalDateTime latestSubmittedDate = databaseManager.getLatestFcaFilingDate(fcaStartDate);
-		List<FcaFiling> filings = fcaClient.fetchAllSinceDate(latestSubmittedDate);
+		LocalDateTime fcaStartDate = null;
+		// Negative `fcaStartDate` value causes full scan of index.
+		// Positive value adds overlap to avoid missed filings due to FCA entries being added out
+		// of `submission-date` order.
+		if (properties.fcaPastDays() >= 0) {
+			fcaStartDate = databaseManager
+					.getLatestFcaFilingDate(LocalDateTime.now());
+			fcaStartDate = fcaStartDate.minusDays(this.properties.fcaPastDays());
+		}
+		List<FcaFiling> filings = fcaClient.fetchAllSinceDate(fcaStartDate);
 		for (FcaFiling filing : filings) {
 			NewFilingRequest newFilingRequest = NewFilingRequest.builder()
 					.companyName(filing.companyName())

--- a/src/main/java/com/frc/codex/properties/impl/FilingIndexPropertiesImpl.java
+++ b/src/main/java/com/frc/codex/properties/impl/FilingIndexPropertiesImpl.java
@@ -138,7 +138,7 @@ public class FilingIndexPropertiesImpl implements FilingIndexProperties {
 		enablePreprocessing = Boolean.parseBoolean(requireNonNull(getEnv(ENABLE_PREPROCESSING, "false")));
 
 		fcaDataApiBaseUrl = requireNonNull(getEnv(FCA_DATA_API_BASE_URL));
-		fcaPastDays = Integer.parseInt(getEnv(FCA_PAST_DAYS, "0"));
+		fcaPastDays = Integer.parseInt(getEnv(FCA_PAST_DAYS, "-1"));
 		fcaSearchApiUrl = requireNonNull(getEnv(FCA_SEARCH_API_URL));
 
 		// Limits must be explicitly overridden


### PR DESCRIPTION
#### Reason for change
Our current FCA indexing process assumes filings are added to the FCA index in `submission_date` order, but that isn't the case. Filings can be added with submission dates earlier than a submission date the indexer has already seen, causing missed filings.

#### Description of change
Filtering/sorting on `last_updated_date` would likely resolve this issue, as it effectively represents the date that the filing was actually added to the index. However, attempting to filter on `last_updated_date` is not supported by the FCA endpoint.

Instead, we can probably capture filings falling into this scenario by simply having the indexer look back further over an overlap window. We already skip filings that already exist so this will not duplicate entries. Examples I've seen would be covered by looking back only 1 day, but a longer overlap period like 30 days doesn't really introduce much cost.

Also added a pathway to force full re-scan on each run (negative `FCA_PAST_DAYS` value), and set this as the default since the cost is currently quite low to do an hourly full rescan. Should be revisited in the future if/when the FCA index grows considerably (50,000+ filings, I'd suggest).

#### Steps to Test
CI

**review**:
@Arelle/arelle
