### PR TITLE
Update FCA search index name and CI failures

### DIFF
--- a/deploy/cfn.yml
+++ b/deploy/cfn.yml
@@ -445,7 +445,7 @@ Resources:
         - Name: "FCA_DATA_API_BASE_URL"
           Value: "https://data.fca.org.uk/artefacts/"
         - Name: "FCA_SEARCH_API_URL"
-          Value: "https://api.data.fca.org.uk/search?index=fca-nsm-searchdata"
+          Value: "https://api.data.fca.org.uk/search?index=nsm-search"
         - Name: "FILING_LIMIT_COMPANIES_HOUSE"
           Value: !Ref CompaniesHouseFilingLimit
         - Name: "FILING_LIMIT_FCA"

--- a/dev/compose.yml
+++ b/dev/compose.yml
@@ -26,7 +26,7 @@ services:
       DB_URL: "jdbc:postgresql://postgres.localhost:5432/frc_codex"
       DB_USERNAME: "frc_codex"
       FCA_DATA_API_BASE_URL: "https://data.fca.org.uk/artefacts/"
-      FCA_SEARCH_API_URL: "https://api.data.fca.org.uk/search?index=fca-nsm-searchdata"
+      FCA_SEARCH_API_URL: "https://api.data.fca.org.uk/search?index=nsm-search"
       JAVA_TOOL_OPTIONS: "-agentlib:jdwp=transport=dt_socket,server=y,address=*:8180,suspend=n"
       METRIC_NAMESPACE: 'frc-codex'
       S3_INDEXER_UPLOADS_BUCKET_NAME: "frc-codex-indexer-uploads"

--- a/dev/smoke-test.sh
+++ b/dev/smoke-test.sh
@@ -2,15 +2,73 @@
 
 set -e
 
-CURL_OPTS=(--include --fail --connect-timeout 30 --max-time 300)
+BASE_CURL_OPTS=(--include --fail --connect-timeout 30)
+CURL_OPTS=("${BASE_CURL_OPTS[@]}" --max-time 300)
 
 echo "Testing survey form submission..."
 curl "${CURL_OPTS[@]}" -X POST http://localhost:8080/survey \
   -H "Content-Type: application/x-www-form-urlencoded" \
   -d "searchUtilityRating=5&searchSpeedRating=4&viewerSpeedRating=3"
-          
+
+CURL_TIMEOUT_EXIT_CODE=28
+FALLBACK_COMPANY_NUMBER=11162569
+FALLBACK_FILING_ID="MzQzOTA3MDIxN2FkaXF6a2N4"
+
+wait_for_smoketest() {
+  local max_time="$1"
+  curl "${BASE_CURL_OPTS[@]}" --silent --max-time "$max_time" http://localhost:8080/admin/smoketest/wait
+}
+
 echo "Wait for smoke testing to be ready..."
-curl "${CURL_OPTS[@]}" --silent http://localhost:8080/admin/smoketest/wait
+wait_status=0
+wait_for_smoketest 60 || wait_status=$?
+if [ $wait_status -ne 0 ]; then
+  if [ $wait_status -ne $CURL_TIMEOUT_EXIT_CODE ]; then
+    echo "ERROR: /admin/smoketest/wait failed with curl exit code $wait_status" >&2
+    exit $wait_status
+  fi
+
+  echo "No Companies House stream event arrived within timeout; injecting fallback stream event for company $FALLBACK_COMPANY_NUMBER (filing $FALLBACK_FILING_ID)..."
+
+  STREAM_EVENT_JSON=$(cat <<EOF
+{
+  "resource_kind": "filing-history",
+  "resource_id": "$FALLBACK_FILING_ID",
+  "resource_uri": "/company/$FALLBACK_COMPANY_NUMBER/filing-history/$FALLBACK_FILING_ID",
+  "event": {
+    "type": "changed",
+    "timepoint": 1
+  },
+  "data": {
+    "transaction_id": "$FALLBACK_FILING_ID",
+    "category": "accounts",
+    "date": "2024-01-01",
+    "action_date": "2024-01-01"
+  }
+}
+EOF
+  )
+
+  set +e
+  POSTGRES_CONTAINER=$(docker compose -f ./dev/compose.yml ps -q postgres)
+  docker exec "$POSTGRES_CONTAINER" psql -U frc_codex -d frc_codex -c \
+    "INSERT INTO stream_events (timepoint, json) VALUES (1, '$STREAM_EVENT_JSON');"
+  insert_status=$?
+  set -e
+
+  if [ $insert_status -ne 0 ]; then
+    echo "ERROR: Could not insert the fallback stream event into stream_events." >&2
+    exit 1
+  fi
+
+  echo "Retrying wait for smoke testing to be ready..."
+  retry_status=0
+  wait_for_smoketest 120 || retry_status=$?
+  if [ $retry_status -ne 0 ]; then
+    echo "ERROR: The fallback stream event for company $FALLBACK_COMPANY_NUMBER (filing $FALLBACK_FILING_ID) could not be processed into a PENDING filing." >&2
+    exit 1
+  fi
+fi
 
 echo "Test invocation"
 curl "${CURL_OPTS[@]}" --silent -L http://localhost:8080/admin/smoketest/invoke

--- a/dev/smoke-test.sh
+++ b/dev/smoke-test.sh
@@ -2,72 +2,72 @@
 
 set -e
 
-CURL_OPTS="--include --fail --connect-timeout 30 --max-time 300"
+CURL_OPTS=(--include --fail --connect-timeout 30 --max-time 300)
 
 echo "Testing survey form submission..."
-curl $CURL_OPTS -X POST http://localhost:8080/survey \
+curl "${CURL_OPTS[@]}" -X POST http://localhost:8080/survey \
   -H "Content-Type: application/x-www-form-urlencoded" \
   -d "searchUtilityRating=5&searchSpeedRating=4&viewerSpeedRating=3"
           
 echo "Wait for smoke testing to be ready..."
-curl $CURL_OPTS --silent http://localhost:8080/admin/smoketest/wait
+curl "${CURL_OPTS[@]}" --silent http://localhost:8080/admin/smoketest/wait
 
 echo "Test invocation"
-curl $CURL_OPTS --silent -L http://localhost:8080/admin/smoketest/invoke
+curl "${CURL_OPTS[@]}" --silent -L http://localhost:8080/admin/smoketest/invoke
 
 echo "Test homepage"
-curl $CURL_OPTS http://localhost:8080/
+curl "${CURL_OPTS[@]}" http://localhost:8080/
 
 echo "Test CH API client"
-curl $CURL_OPTS http://localhost:8080/admin/smoketest/companieshouse/company/10178367
+curl "${CURL_OPTS[@]}" http://localhost:8080/admin/smoketest/companieshouse/company/10178367
 
 echo "Test CH archive client"
-curl $CURL_OPTS http://localhost:8080/admin/smoketest/companieshouse/history
+curl "${CURL_OPTS[@]}" http://localhost:8080/admin/smoketest/companieshouse/history
 
 echo "Test FCA API"
-curl $CURL_OPTS http://localhost:8080/admin/smoketest/fca
+curl "${CURL_OPTS[@]}" http://localhost:8080/admin/smoketest/fca
 
 echo "Test indexer page"
-curl $CURL_OPTS http://localhost:8080/admin/smoketest/indexer
+curl "${CURL_OPTS[@]}" http://localhost:8080/admin/smoketest/indexer
 
 echo "Test queue page"
-curl $CURL_OPTS http://localhost:8080/admin/smoketest/queue
+curl "${CURL_OPTS[@]}" http://localhost:8080/admin/smoketest/queue
 
 echo "Test database page"
-curl $CURL_OPTS http://localhost:8080/admin/smoketest/database
+curl "${CURL_OPTS[@]}" http://localhost:8080/admin/smoketest/database
 
 echo "Test support action: delete_filing"
-curl $CURL_OPTS 'localhost:8082/2015-03-31/functions/function/invocations' \
+curl "${CURL_OPTS[@]}" 'localhost:8082/2015-03-31/functions/function/invocations' \
   --data '{"action":"delete_filing","filing_id": "cfc59bc3-1899-40ae-87f3-bd199bee8171", "test_mode": true}'
 
 echo "Test support action: get_ch_indexing_stats"
-curl $CURL_OPTS 'localhost:8082/2015-03-31/functions/function/invocations' \
+curl "${CURL_OPTS[@]}" 'localhost:8082/2015-03-31/functions/function/invocations' \
   --data '{"action":"get_ch_indexing_stats"}'
 
 echo "Test support action: get_ch_streaming_stats"
-curl $CURL_OPTS 'localhost:8082/2015-03-31/functions/function/invocations' \
+curl "${CURL_OPTS[@]}" 'localhost:8082/2015-03-31/functions/function/invocations' \
   --data '{"action":"get_ch_streaming_stats"}'
 
 echo "Test support action: get_filing_details"
-curl $CURL_OPTS 'localhost:8082/2015-03-31/functions/function/invocations' \
+curl "${CURL_OPTS[@]}" 'localhost:8082/2015-03-31/functions/function/invocations' \
   --data '{"action":"get_filing_details","filing_id":"cfc59bc3-1899-40ae-87f3-bd199bee8171"}'
 
 echo "Test support action: list_errors"
-curl $CURL_OPTS 'localhost:8082/2015-03-31/functions/function/invocations' \
+curl "${CURL_OPTS[@]}" 'localhost:8082/2015-03-31/functions/function/invocations' \
   --data '{"action":"list_errors"}'
 
 echo "Test support action: reset_archives"
-curl $CURL_OPTS 'localhost:8082/2015-03-31/functions/function/invocations' \
+curl "${CURL_OPTS[@]}" 'localhost:8082/2015-03-31/functions/function/invocations' \
   --data '{"action":"reset_archives","archive_type":"daily"}'
 
 echo "Test support action: reset_companies"
-curl $CURL_OPTS 'localhost:8082/2015-03-31/functions/function/invocations' \
+curl "${CURL_OPTS[@]}" 'localhost:8082/2015-03-31/functions/function/invocations' \
   --data '{"action":"reset_companies","company_number":"1234567890"}'
 
 echo "Test support action: reset_filings"
-curl $CURL_OPTS 'localhost:8082/2015-03-31/functions/function/invocations' \
+curl "${CURL_OPTS[@]}" 'localhost:8082/2015-03-31/functions/function/invocations' \
   --data '{"action":"reset_filings","company_number":"1234567890"}'
 
 echo "Test support action: reset_stream_events"
-curl $CURL_OPTS 'localhost:8082/2015-03-31/functions/function/invocations' \
+curl "${CURL_OPTS[@]}" 'localhost:8082/2015-03-31/functions/function/invocations' \
   --data '{"action":"reset_stream_events","timepoint_before":0}'

--- a/src/main/java/com/frc/codex/clients/fca/FCA.md
+++ b/src/main/java/com/frc/codex/clients/fca/FCA.md
@@ -6,7 +6,7 @@ Instead, we can recreate the requests generated on [their search page](https://d
 
 Example search request:
 ```
-POST https://api.data.fca.org.uk/search?index=fca-nsm-searchdata
+POST https://api.data.fca.org.uk/search?index=nsm-search
 {
   "from": 0,
   "size": 50,
@@ -60,7 +60,7 @@ Example response:
     "max_score": null,
     "hits": [
       {
-        "_index": "fca-nsm-searchdata",
+        "_index": "nsm-search",
         "_type": "_doc",
         "_id": "NI-000103799-0",
         "_score": null,

--- a/src/main/java/com/frc/codex/clients/fca/impl/FcaClientImpl.java
+++ b/src/main/java/com/frc/codex/clients/fca/impl/FcaClientImpl.java
@@ -103,12 +103,18 @@ public class FcaClientImpl implements FcaClient {
 		headers.setAccept(List.of(MediaType.APPLICATION_JSON));
 		String body = buildJson(sinceDate, page);
 		HttpEntity<String> entity = new HttpEntity<>(body, headers);
-		ResponseEntity<String> response = restTemplate.exchange(
-				this.searchApiUrl,
-				HttpMethod.POST,
-				entity,
-				String.class
-		);
+		ResponseEntity<String> response;
+		try {
+			response = restTemplate.exchange(
+					this.searchApiUrl,
+					HttpMethod.POST,
+					entity,
+					String.class
+			);
+		} catch (Exception e) {
+			LOG.error("FCA search request failed: POST {}", this.searchApiUrl, e);
+			throw e;
+		}
 		int processed = processPage(response, filings);
 		return processed >= this.pageSize;
 	}

--- a/src/main/java/com/frc/codex/controllers/AdminController.java
+++ b/src/main/java/com/frc/codex/controllers/AdminController.java
@@ -2,8 +2,11 @@ package com.frc.codex.controllers;
 
 import java.net.URI;
 import java.time.LocalDateTime;
+import java.util.Arrays;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -270,7 +273,9 @@ public class AdminController extends BaseController {
 			}
 			filingsReady = filings.size() >= RegistryCode.values().length;
 			if (!filingsReady) {
-				LOG.info("Waiting for filings to be ready for smoke testing...");
+				Set<RegistryCode> missing = new HashSet<>(Arrays.asList(RegistryCode.values()));
+				missing.removeAll(filings.keySet());
+				LOG.info("Waiting for PENDING filings from registries: {}", missing);
 				Thread.sleep(5000);
 			}
 		}


### PR DESCRIPTION
#### Description of change

- Update FCA search API index name (`fca-nsm-searchdata` → `nsm-search`) after [FCA renamed it ](https://data.fca.org.uk/#/nsm/nationalstoragemechanism)(requests in prod are all returning 400)
- Add CH stream fallback so CI doesn't hang waiting for real stream events outside UK business hours
- Log which registries the smoke test wait endpoint is still waiting on

#### Steps to Test

* CI

**review**:
@Arelle/arelle
