### PR TITLE
Instrument CH stream health

### DIFF
--- a/deploy/cfn.yml
+++ b/deploy/cfn.yml
@@ -474,6 +474,8 @@ Resources:
           Value: !Sub "${EnvironmentName}-server-stream-discovery-delay"
         - Name: "STREAM_EVENTS_METRIC"
           Value: !Sub "${EnvironmentName}-server-stream-events"
+        - Name: "STREAM_RECEIVED_EVENTS_AGE_METRIC"
+          Value: !Sub "${EnvironmentName}-server-stream-received-events-age"
         - Name: "SUPPORT_EMAIL"
           Value: !Ref SupportEmail
         - Name: "UNPROCESSED_COMPANIES_LIMIT"

--- a/deploy/cfn.yml
+++ b/deploy/cfn.yml
@@ -472,6 +472,8 @@ Resources:
           Value: unused
         - Name: "STREAM_DISCOVERY_DELAY_METRIC"
           Value: !Sub "${EnvironmentName}-server-stream-discovery-delay"
+        - Name: "STREAM_EVENTS_HEAD_AGE_METRIC"
+          Value: !Sub "${EnvironmentName}-server-stream-events-head-age"
         - Name: "STREAM_EVENTS_METRIC"
           Value: !Sub "${EnvironmentName}-server-stream-events"
         - Name: "STREAM_RECEIVED_EVENTS_AGE_METRIC"

--- a/dev/compose.yml
+++ b/dev/compose.yml
@@ -34,6 +34,7 @@ services:
       SQS_JOBS_QUEUE_NAME: "frc_codex_jobs"
       SQS_RESULTS_QUEUE_NAME: "frc_codex_results"
       STREAM_EVENTS_METRIC: "stream-events"
+      STREAM_EVENTS_HEAD_AGE_METRIC: "stream-events-head-age"
       STREAM_RECEIVED_EVENTS_AGE_METRIC: "stream-received-events-age"
       STREAM_DISCOVERY_DELAY_METRIC: "stream-discovery-delay"
       SUPPORT_EMAIL: "dev@localhost"

--- a/dev/compose.yml
+++ b/dev/compose.yml
@@ -34,6 +34,7 @@ services:
       SQS_JOBS_QUEUE_NAME: "frc_codex_jobs"
       SQS_RESULTS_QUEUE_NAME: "frc_codex_results"
       STREAM_EVENTS_METRIC: "stream-events"
+      STREAM_RECEIVED_EVENTS_AGE_METRIC: "stream-received-events-age"
       STREAM_DISCOVERY_DELAY_METRIC: "stream-discovery-delay"
       SUPPORT_EMAIL: "dev@localhost"
     secrets:

--- a/src/main/java/com/frc/codex/clients/companieshouse/CompaniesHouseStreamListener.java
+++ b/src/main/java/com/frc/codex/clients/companieshouse/CompaniesHouseStreamListener.java
@@ -1,7 +1,9 @@
 package com.frc.codex.clients.companieshouse;
 
+import java.time.Instant;
+
 import com.frc.codex.indexer.IndexerJob;
 
 public interface CompaniesHouseStreamListener extends IndexerJob {
-
+	Instant getLastEventReceivedDate();
 }

--- a/src/main/java/com/frc/codex/clients/companieshouse/impl/CompaniesHouseStreamIndexerImpl.java
+++ b/src/main/java/com/frc/codex/clients/companieshouse/impl/CompaniesHouseStreamIndexerImpl.java
@@ -178,7 +178,7 @@ public class CompaniesHouseStreamIndexerImpl implements CompaniesHouseStreamInde
 				}
 				throw e;
 			} catch (Exception e) {
-				LOG.error("Failed to handle CH filing stream event.", e);
+				LOG.error("Failed to handle CH filing stream event: {}", streamEvent.getStreamEventId(), e);
 				break;
 			}
 

--- a/src/main/java/com/frc/codex/clients/companieshouse/impl/CompaniesHouseStreamListenerImpl.java
+++ b/src/main/java/com/frc/codex/clients/companieshouse/impl/CompaniesHouseStreamListenerImpl.java
@@ -1,6 +1,8 @@
 package com.frc.codex.clients.companieshouse.impl;
 
 import java.io.IOException;
+import java.time.Duration;
+import java.time.Instant;
 import java.util.Date;
 import java.util.function.Function;
 import java.util.function.Supplier;
@@ -12,6 +14,8 @@ import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.HttpStatusCodeException;
 
+import jakarta.annotation.PostConstruct;
+
 import com.frc.codex.clients.companieshouse.CompaniesHouseClient;
 import com.frc.codex.clients.companieshouse.CompaniesHouseStreamListener;
 import com.frc.codex.clients.companieshouse.RateLimitException;
@@ -20,10 +24,13 @@ import com.frc.codex.database.DatabaseManager;
 @Component
 public class CompaniesHouseStreamListenerImpl implements CompaniesHouseStreamListener {
 	private static final Logger LOG = LoggerFactory.getLogger(CompaniesHouseStreamListenerImpl.class);
+	private static final Duration RECEIPT_PERSIST_INTERVAL = Duration.ofMinutes(1);
 	private final CompaniesHouseClient companiesHouseClient;
 	private final DatabaseManager databaseManager;
 	private int companiesHouseSessionEventCount;
 	private Date companiesHouseStreamLastOpenedDate;
+	private volatile Instant lastEventReceivedDate;
+	private Instant lastPersistedEventReceivedDate;
 	private final Pattern timepointPattern;
 
 	public CompaniesHouseStreamListenerImpl(
@@ -35,14 +42,51 @@ public class CompaniesHouseStreamListenerImpl implements CompaniesHouseStreamLis
 		this.timepointPattern = Pattern.compile("\"timepoint\":(\\d+)");
 	}
 
+	public Instant getLastEventReceivedDate() {
+		return lastEventReceivedDate;
+	}
+
+	@PostConstruct
+	public void postConstruct() {
+		try {
+			Instant receivedDate = databaseManager.getLastStreamEventReceivedDate();
+			lastEventReceivedDate = receivedDate == null ? Instant.now() : receivedDate;
+		} catch (RuntimeException e) {
+			LOG.warn("Could not read the last stream event receipt date. Its age will go unpublished.", e);
+			lastEventReceivedDate = null;
+		}
+		lastPersistedEventReceivedDate = lastEventReceivedDate;
+	}
+
 	public String getStatus() {
+		Instant receivedDate = lastEventReceivedDate;
+		String lastEventReceived = receivedDate == null ? "unknown" : "%s (%s seconds ago)".formatted(
+				receivedDate,
+				Duration.between(receivedDate, Instant.now()).toSeconds()
+		);
 		return String.format("""
 						Companies House Stream Listener:
 						\tStream last opened: %s
-						\tEvents discovered this session: %s""",
+						\tEvents discovered this session: %s
+						\tLast event received: %s""",
 				companiesHouseStreamLastOpenedDate,
-				companiesHouseSessionEventCount
+				companiesHouseSessionEventCount,
+				lastEventReceived
 		);
+	}
+
+	private void recordEventReceived(Instant receivedDate) {
+		lastEventReceivedDate = receivedDate;
+		if (lastPersistedEventReceivedDate != null
+				&& Duration.between(lastPersistedEventReceivedDate, receivedDate).compareTo(RECEIPT_PERSIST_INTERVAL) < 0) {
+			return;
+		}
+		try {
+			databaseManager.updateLastStreamEventReceivedDate(receivedDate);
+			lastPersistedEventReceivedDate = receivedDate;
+		} catch (RuntimeException e) {
+			LOG.warn("Could not record the last stream event receipt date.", e);
+		}
 	}
 
 	public boolean isHealthy() {
@@ -63,6 +107,7 @@ public class CompaniesHouseStreamListenerImpl implements CompaniesHouseStreamLis
 			long timepoint = Long.parseLong(matcher.group(1));
 			databaseManager.createStreamEvent(timepoint, json);
 			companiesHouseSessionEventCount++;
+			recordEventReceived(Instant.now());
 			return true; // Continue streaming
 		};
 		Long startTimepoint = databaseManager.getLatestStreamTimepoint(null);

--- a/src/main/java/com/frc/codex/database/DatabaseManager.java
+++ b/src/main/java/com/frc/codex/database/DatabaseManager.java
@@ -15,6 +15,7 @@ import com.frc.codex.model.FilingStatus;
 import com.frc.codex.model.NewFilingRequest;
 import com.frc.codex.model.SearchFilingsRequest;
 import com.frc.codex.model.StreamEvent;
+import com.frc.codex.model.StreamEventsStats;
 import com.frc.codex.model.companieshouse.CompaniesHouseArchive;
 
 public interface DatabaseManager {
@@ -41,7 +42,7 @@ public interface DatabaseManager {
 	long getRegistryCount(RegistryCode registryCode);
 	void resetCompany(String companyNumber);
 	List<StreamEvent> getStreamEvents(long limit);
-	long getStreamEventsCount();
+	StreamEventsStats getStreamEventsStats();
 	void resetFiling(UUID filingId);
 	List<Filing> searchFilings(SearchFilingsRequest searchFilingsRequest);
 	void updateFilingStatus(UUID filingId, String status);

--- a/src/main/java/com/frc/codex/database/DatabaseManager.java
+++ b/src/main/java/com/frc/codex/database/DatabaseManager.java
@@ -1,5 +1,6 @@
 package com.frc.codex.database;
 
+import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -33,6 +34,7 @@ public interface DatabaseManager {
 	List<Filing> getFilingsByStatus(FilingStatus status);
 	List<Filing> getFilingsByStatus(FilingStatus status, RegistryCode registryCode);
 	long getFilingsCount(SearchFilingsRequest searchFilingsRequest);
+	Instant getLastStreamEventReceivedDate();
 	LocalDateTime getLatestFcaFilingDate(LocalDateTime defaultDate);
 	LocalDateTime getLatestStreamDiscoveredDate();
 	Long getLatestStreamTimepoint(Long defaultTimepoint);
@@ -43,6 +45,7 @@ public interface DatabaseManager {
 	void resetFiling(UUID filingId);
 	List<Filing> searchFilings(SearchFilingsRequest searchFilingsRequest);
 	void updateFilingStatus(UUID filingId, String status);
+	void updateLastStreamEventReceivedDate(Instant receivedDate);
 	Set<String> getCompaniesCompanyNumbers();
 	void createCompany(Company company);
 	void updateCompany(Company company);

--- a/src/main/java/com/frc/codex/database/impl/DatabaseManagerImpl.java
+++ b/src/main/java/com/frc/codex/database/impl/DatabaseManagerImpl.java
@@ -39,6 +39,7 @@ import com.frc.codex.model.NewFilingRequest;
 import com.frc.codex.model.RegistryCode;
 import com.frc.codex.model.SearchFilingsRequest;
 import com.frc.codex.model.StreamEvent;
+import com.frc.codex.model.StreamEventsStats;
 import com.frc.codex.model.companieshouse.CompaniesHouseArchive;
 import com.frc.codex.properties.FilingIndexProperties;
 import com.google.common.collect.ImmutableList;
@@ -489,13 +490,20 @@ public class DatabaseManagerImpl implements AutoCloseable, DatabaseManager {
 		}
 	}
 
-	public long getStreamEventsCount() {
+	public StreamEventsStats getStreamEventsStats() {
 		try (Connection connection = getInitializedConnection(true)) {
-			String sql = "SELECT COUNT(*) FROM stream_events;";
+			String sql = """
+					SELECT
+						COUNT(*),
+						COALESCE(EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - MIN(created_date)))::BIGINT, 0)
+					FROM stream_events;""";
 			PreparedStatement statement = connection.prepareStatement(sql);
 			ResultSet resultSet = statement.executeQuery();
 			resultSet.next();
-			return resultSet.getLong(1);
+			return new StreamEventsStats(
+					resultSet.getLong(1),
+					resultSet.getLong(2)
+			);
 		} catch (SQLException e) {
 			throw new RuntimeException(e);
 		}

--- a/src/main/java/com/frc/codex/database/impl/DatabaseManagerImpl.java
+++ b/src/main/java/com/frc/codex/database/impl/DatabaseManagerImpl.java
@@ -328,6 +328,21 @@ public class DatabaseManagerImpl implements AutoCloseable, DatabaseManager {
 		}
 	}
 
+	public Instant getLastStreamEventReceivedDate() {
+		try (Connection connection = getInitializedConnection(true)) {
+			String sql = "SELECT last_received_date FROM stream_receipts WHERE id = 1";
+			PreparedStatement statement = connection.prepareStatement(sql);
+			ResultSet resultSet = statement.executeQuery();
+			if (!resultSet.next()) {
+				return null;
+			}
+			Timestamp lastReceivedDate = resultSet.getTimestamp(1);
+			return lastReceivedDate == null ? null : lastReceivedDate.toInstant();
+		} catch (SQLException e) {
+			throw new RuntimeException(e);
+		}
+	}
+
 	public LocalDateTime getLatestFcaFilingDate(LocalDateTime defaultDate) {
 		try (Connection connection = getInitializedConnection(true)) {
 			String sql = "SELECT MAX(filing_date) FROM filings WHERE registry_code = 'FCA'";
@@ -506,6 +521,20 @@ public class DatabaseManagerImpl implements AutoCloseable, DatabaseManager {
 	private Connection getInitializedConnection(boolean readOnly) throws SQLException {
 		DataSource dataSource = readOnly ? readDataSource : writeDataSource;
 		return dataSource.getConnection();
+	}
+
+	public void updateLastStreamEventReceivedDate(Instant receivedDate) {
+		try (Connection connection = getInitializedConnection(false)) {
+			String sql = """
+					INSERT INTO stream_receipts (id, last_received_date) VALUES (1, ?)
+					ON CONFLICT (id) DO UPDATE SET last_received_date = EXCLUDED.last_received_date;""";
+			PreparedStatement statement = connection.prepareStatement(sql);
+			statement.setTimestamp(1, Timestamp.from(receivedDate));
+			statement.executeUpdate();
+			connection.commit();
+		} catch (SQLException e) {
+			throw new RuntimeException(e);
+		}
 	}
 
 	public void updateFilingStatus(UUID filingId, String status) {

--- a/src/main/java/com/frc/codex/indexer/impl/MetricManagerImpl.java
+++ b/src/main/java/com/frc/codex/indexer/impl/MetricManagerImpl.java
@@ -1,6 +1,7 @@
 package com.frc.codex.indexer.impl;
 
 import java.time.Duration;
+import java.time.Instant;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
@@ -10,6 +11,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
+import com.frc.codex.clients.companieshouse.CompaniesHouseClient;
+import com.frc.codex.clients.companieshouse.CompaniesHouseStreamListener;
 import com.frc.codex.database.DatabaseManager;
 import com.frc.codex.indexer.MetricManager;
 import com.frc.codex.properties.FilingIndexProperties;
@@ -24,10 +27,19 @@ import software.amazon.awssdk.services.cloudwatch.model.StandardUnit;
 public class MetricManagerImpl implements MetricManager {
 	private static final Logger LOG = LoggerFactory.getLogger(MetricManagerImpl.class);
 	private final CloudWatchClient client;
+	private final CompaniesHouseClient companiesHouseClient;
+	private final CompaniesHouseStreamListener companiesHouseStreamListener;
 	private final DatabaseManager databaseManager;
 	private final FilingIndexProperties properties;
 
-	public MetricManagerImpl(DatabaseManager databaseManager, FilingIndexProperties properties) {
+	public MetricManagerImpl(
+			CompaniesHouseClient companiesHouseClient,
+			CompaniesHouseStreamListener companiesHouseStreamListener,
+			DatabaseManager databaseManager,
+			FilingIndexProperties properties
+	) {
+		this.companiesHouseClient = companiesHouseClient;
+		this.companiesHouseStreamListener = companiesHouseStreamListener;
 		this.databaseManager = databaseManager;
 		this.properties = properties;
 		this.client = CloudWatchClient.create();
@@ -40,6 +52,7 @@ public class MetricManagerImpl implements MetricManager {
 		}
 		List<MetricDatum> metricData = new ArrayList<>();
 		collect(metricData, "stream discovery delay", this::addStreamDiscoveryDelayMetricDatum);
+		collect(metricData, "stream received events age", this::addStreamReceivedEventsAgeMetricDatum);
 		collect(metricData, "stream events", this::addStreamEventsMetricDatum);
 		if (metricData.isEmpty()) {
 			LOG.debug("No metrics to upload, skipping metric upload.");
@@ -93,6 +106,27 @@ public class MetricManagerImpl implements MetricManager {
 			return;
 		}
 		addMetricDatum(metricData, this.properties.streamEventsMetric(), this.databaseManager.getStreamEventsCount(), StandardUnit.COUNT);
+	}
+
+	private void addStreamReceivedEventsAgeMetricDatum(List<MetricDatum> metricData) {
+		if (this.properties.streamReceivedEventsAgeMetric() == null) {
+			LOG.debug("No stream received events age metric name configured, skipping that metric.");
+			return;
+		}
+		if (!this.companiesHouseClient.isEnabled()) {
+			LOG.debug("Companies House client is disabled, skipping stream received events age metric.");
+			return;
+		}
+		Instant lastEventReceivedDate = this.companiesHouseStreamListener.getLastEventReceivedDate();
+		if (lastEventReceivedDate == null) {
+			LOG.debug("No stream event receipt date available, skipping stream received events age metric.");
+			return;
+		}
+		long receivedEventsAge = Duration.between(lastEventReceivedDate, Instant.now()).toSeconds();
+		if (receivedEventsAge < 0) {
+			receivedEventsAge = 0;
+		}
+		addMetricDatum(metricData, this.properties.streamReceivedEventsAgeMetric(), receivedEventsAge, StandardUnit.SECONDS);
 	}
 
 }

--- a/src/main/java/com/frc/codex/indexer/impl/MetricManagerImpl.java
+++ b/src/main/java/com/frc/codex/indexer/impl/MetricManagerImpl.java
@@ -2,9 +2,8 @@ package com.frc.codex.indexer.impl;
 
 import java.time.Duration;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
-import java.util.Objects;
-import java.util.stream.Stream;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -38,11 +37,9 @@ public class MetricManagerImpl implements MetricManager {
 			LOG.debug("No metric namespace configured, skipping metric upload.");
 			return;
 		}
-		List<MetricDatum> metricData = Stream.of(
-						buildStreamDiscoveryDelayMetricDatum(),
-						buildStreamEventsMetricDatum())
-				.filter(Objects::nonNull)
-				.toList();
+		List<MetricDatum> metricData = new ArrayList<>();
+		addStreamDiscoveryDelayMetricDatum(metricData);
+		addStreamEventsMetricDatum(metricData);
 		if (metricData.isEmpty()) {
 			LOG.debug("No metrics to upload, skipping metric upload.");
 			return;
@@ -57,37 +54,36 @@ public class MetricManagerImpl implements MetricManager {
 		}
 	}
 
-	private MetricDatum buildStreamDiscoveryDelayMetricDatum() {
+	private void addMetricDatum(List<MetricDatum> metricData, String metricName, long value, StandardUnit unit) {
+		metricData.add(MetricDatum.builder()
+				.metricName(metricName)
+				.value((double) value)
+				.unit(unit)
+				.build());
+	}
+
+	private void addStreamDiscoveryDelayMetricDatum(List<MetricDatum> metricData) {
 		if (this.properties.streamDiscoveryDelayMetric() == null) {
-			LOG.debug("No stream discovery delay metric name configured, skipping metric upload.");
-			return null;
+			LOG.debug("No stream discovery delay metric name configured, skipping that metric.");
+			return;
 		}
 		LocalDateTime latestStreamDiscoveredDate = this.databaseManager.getLatestStreamDiscoveredDate();
-		int streamDiscoveryDelay = 0;
+		long streamDiscoveryDelay = 0;
 		if (latestStreamDiscoveredDate != null) {
-			streamDiscoveryDelay = (int) Duration.between(latestStreamDiscoveredDate, LocalDateTime.now()).toSeconds();
+			streamDiscoveryDelay = Duration.between(latestStreamDiscoveredDate, LocalDateTime.now()).toSeconds();
 			if (streamDiscoveryDelay < 0) {
 				streamDiscoveryDelay = 0;
 			}
 		}
-		return MetricDatum.builder()
-				.metricName(this.properties.streamDiscoveryDelayMetric())
-				.value((double) streamDiscoveryDelay)
-				.unit(StandardUnit.SECONDS)
-				.build();
+		addMetricDatum(metricData, this.properties.streamDiscoveryDelayMetric(), streamDiscoveryDelay, StandardUnit.SECONDS);
 	}
 
-	private MetricDatum buildStreamEventsMetricDatum() {
+	private void addStreamEventsMetricDatum(List<MetricDatum> metricData) {
 		if (this.properties.streamEventsMetric() == null) {
-			LOG.debug("No stream events metric name configured, skipping metric upload.");
-			return null;
+			LOG.debug("No stream events metric name configured, skipping that metric.");
+			return;
 		}
-		long streamEventsCount = this.databaseManager.getStreamEventsCount();
-		return MetricDatum.builder()
-				.metricName(this.properties.streamEventsMetric())
-				.value((double) streamEventsCount)
-				.unit(StandardUnit.COUNT)
-				.build();
+		addMetricDatum(metricData, this.properties.streamEventsMetric(), this.databaseManager.getStreamEventsCount(), StandardUnit.COUNT);
 	}
 
 }

--- a/src/main/java/com/frc/codex/indexer/impl/MetricManagerImpl.java
+++ b/src/main/java/com/frc/codex/indexer/impl/MetricManagerImpl.java
@@ -15,6 +15,7 @@ import com.frc.codex.clients.companieshouse.CompaniesHouseClient;
 import com.frc.codex.clients.companieshouse.CompaniesHouseStreamListener;
 import com.frc.codex.database.DatabaseManager;
 import com.frc.codex.indexer.MetricManager;
+import com.frc.codex.model.StreamEventsStats;
 import com.frc.codex.properties.FilingIndexProperties;
 
 import software.amazon.awssdk.services.cloudwatch.CloudWatchClient;
@@ -53,7 +54,7 @@ public class MetricManagerImpl implements MetricManager {
 		List<MetricDatum> metricData = new ArrayList<>();
 		collect(metricData, "stream discovery delay", this::addStreamDiscoveryDelayMetricDatum);
 		collect(metricData, "stream received events age", this::addStreamReceivedEventsAgeMetricDatum);
-		collect(metricData, "stream events", this::addStreamEventsMetricDatum);
+		collect(metricData, "stream events", this::addStreamEventsMetricData);
 		if (metricData.isEmpty()) {
 			LOG.debug("No metrics to upload, skipping metric upload.");
 			return;
@@ -100,12 +101,20 @@ public class MetricManagerImpl implements MetricManager {
 		addMetricDatum(metricData, this.properties.streamDiscoveryDelayMetric(), streamDiscoveryDelay, StandardUnit.SECONDS);
 	}
 
-	private void addStreamEventsMetricDatum(List<MetricDatum> metricData) {
-		if (this.properties.streamEventsMetric() == null) {
-			LOG.debug("No stream events metric name configured, skipping that metric.");
+	private void addStreamEventsMetricData(List<MetricDatum> metricData) {
+		String eventsMetric = this.properties.streamEventsMetric();
+		String headAgeMetric = this.properties.streamEventsHeadAgeMetric();
+		if (eventsMetric == null && headAgeMetric == null) {
+			LOG.debug("No stream events metric names configured, skipping those metrics.");
 			return;
 		}
-		addMetricDatum(metricData, this.properties.streamEventsMetric(), this.databaseManager.getStreamEventsCount(), StandardUnit.COUNT);
+		StreamEventsStats stats = this.databaseManager.getStreamEventsStats();
+		if (eventsMetric != null) {
+			addMetricDatum(metricData, eventsMetric, stats.eventsCount(), StandardUnit.COUNT);
+		}
+		if (headAgeMetric != null) {
+			addMetricDatum(metricData, headAgeMetric, stats.headAgeSeconds(), StandardUnit.SECONDS);
+		}
 	}
 
 	private void addStreamReceivedEventsAgeMetricDatum(List<MetricDatum> metricData) {

--- a/src/main/java/com/frc/codex/indexer/impl/MetricManagerImpl.java
+++ b/src/main/java/com/frc/codex/indexer/impl/MetricManagerImpl.java
@@ -4,6 +4,7 @@ import java.time.Duration;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.function.Consumer;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -38,8 +39,8 @@ public class MetricManagerImpl implements MetricManager {
 			return;
 		}
 		List<MetricDatum> metricData = new ArrayList<>();
-		addStreamDiscoveryDelayMetricDatum(metricData);
-		addStreamEventsMetricDatum(metricData);
+		collect(metricData, "stream discovery delay", this::addStreamDiscoveryDelayMetricDatum);
+		collect(metricData, "stream events", this::addStreamEventsMetricDatum);
 		if (metricData.isEmpty()) {
 			LOG.debug("No metrics to upload, skipping metric upload.");
 			return;
@@ -51,6 +52,14 @@ public class MetricManagerImpl implements MetricManager {
 		PutMetricDataResponse response = this.client.putMetricData(request);
 		if (!response.sdkHttpResponse().isSuccessful()) {
 			LOG.error("Failed to upload metric: {} {}", response.sdkHttpResponse().statusCode(), response.sdkHttpResponse().statusText());
+		}
+	}
+
+	private void collect(List<MetricDatum> metricData, String description, Consumer<List<MetricDatum>> collector) {
+		try {
+			collector.accept(metricData);
+		} catch (RuntimeException e) {
+			LOG.warn("Failed to collect the {} metric.", description, e);
 		}
 	}
 

--- a/src/main/java/com/frc/codex/model/StreamEventsStats.java
+++ b/src/main/java/com/frc/codex/model/StreamEventsStats.java
@@ -1,0 +1,6 @@
+package com.frc.codex.model;
+
+public record StreamEventsStats(
+		long eventsCount,
+		long headAgeSeconds
+) { }

--- a/src/main/java/com/frc/codex/properties/FilingIndexProperties.java
+++ b/src/main/java/com/frc/codex/properties/FilingIndexProperties.java
@@ -42,6 +42,7 @@ public interface FilingIndexProperties {
 	String sqsResultsQueueName();
 	String streamDiscoveryDelayMetric();
 	String streamEventsMetric();
+	String streamReceivedEventsAgeMetric();
 	String supportEmail();
 	int dbHealthCheckTimeout();
 

--- a/src/main/java/com/frc/codex/properties/FilingIndexProperties.java
+++ b/src/main/java/com/frc/codex/properties/FilingIndexProperties.java
@@ -41,6 +41,7 @@ public interface FilingIndexProperties {
 	String sqsJobsQueueName();
 	String sqsResultsQueueName();
 	String streamDiscoveryDelayMetric();
+	String streamEventsHeadAgeMetric();
 	String streamEventsMetric();
 	String streamReceivedEventsAgeMetric();
 	String supportEmail();

--- a/src/main/java/com/frc/codex/properties/impl/FilingIndexPropertiesImpl.java
+++ b/src/main/java/com/frc/codex/properties/impl/FilingIndexPropertiesImpl.java
@@ -57,6 +57,7 @@ public class FilingIndexPropertiesImpl implements FilingIndexProperties {
 	private static final String SQS_JOBS_QUEUE_NAME = "SQS_JOBS_QUEUE_NAME";
 	private static final String SQS_RESULTS_QUEUE_NAME = "SQS_RESULTS_QUEUE_NAME";
 	private static final String STREAM_DISCOVERY_DELAY_METRIC = "STREAM_DISCOVERY_DELAY_METRIC";
+	private static final String STREAM_EVENTS_HEAD_AGE_METRIC = "STREAM_EVENTS_HEAD_AGE_METRIC";
 	private static final String STREAM_EVENTS_METRIC = "STREAM_EVENTS_METRIC";
 	private static final String STREAM_RECEIVED_EVENTS_AGE_METRIC = "STREAM_RECEIVED_EVENTS_AGE_METRIC";
 	private static final String SUPPORT_EMAIL = "SUPPORT_EMAIL";
@@ -99,6 +100,7 @@ public class FilingIndexPropertiesImpl implements FilingIndexProperties {
 	private final String sqsJobsQueueName;
 	private final String sqsResultsQueueName;
 	private final String streamDiscoveryDelayMetric;
+	private final String streamEventsHeadAgeMetric;
 	private final String streamEventsMetric;
 	private final String streamReceivedEventsAgeMetric;
 	private final String supportEmail;
@@ -162,6 +164,7 @@ public class FilingIndexPropertiesImpl implements FilingIndexProperties {
 		sqsResultsQueueName = requireNonNull(getEnv(SQS_RESULTS_QUEUE_NAME));
 
 		streamDiscoveryDelayMetric = requireNonNull(getEnv(STREAM_DISCOVERY_DELAY_METRIC, null));
+		streamEventsHeadAgeMetric = requireNonNull(getEnv(STREAM_EVENTS_HEAD_AGE_METRIC, null));
 		streamEventsMetric = requireNonNull(getEnv(STREAM_EVENTS_METRIC, null));
 		streamReceivedEventsAgeMetric = requireNonNull(getEnv(STREAM_RECEIVED_EVENTS_AGE_METRIC, null));
 
@@ -384,6 +387,10 @@ public class FilingIndexPropertiesImpl implements FilingIndexProperties {
 
 	public String streamDiscoveryDelayMetric() {
 		return streamDiscoveryDelayMetric;
+	}
+
+	public String streamEventsHeadAgeMetric() {
+		return streamEventsHeadAgeMetric;
 	}
 
 	public String streamEventsMetric() {

--- a/src/main/java/com/frc/codex/properties/impl/FilingIndexPropertiesImpl.java
+++ b/src/main/java/com/frc/codex/properties/impl/FilingIndexPropertiesImpl.java
@@ -58,6 +58,7 @@ public class FilingIndexPropertiesImpl implements FilingIndexProperties {
 	private static final String SQS_RESULTS_QUEUE_NAME = "SQS_RESULTS_QUEUE_NAME";
 	private static final String STREAM_DISCOVERY_DELAY_METRIC = "STREAM_DISCOVERY_DELAY_METRIC";
 	private static final String STREAM_EVENTS_METRIC = "STREAM_EVENTS_METRIC";
+	private static final String STREAM_RECEIVED_EVENTS_AGE_METRIC = "STREAM_RECEIVED_EVENTS_AGE_METRIC";
 	private static final String SUPPORT_EMAIL = "SUPPORT_EMAIL";
 	private static final String UNPROCESSED_COMPANIES_LIMIT = "UNPROCESSED_COMPANIES_LIMIT";
 	private final String adminCookieName;
@@ -99,6 +100,7 @@ public class FilingIndexPropertiesImpl implements FilingIndexProperties {
 	private final String sqsResultsQueueName;
 	private final String streamDiscoveryDelayMetric;
 	private final String streamEventsMetric;
+	private final String streamReceivedEventsAgeMetric;
 	private final String supportEmail;
 	private final int unprocessedCompaniesLimit;
 	private final String httpUsername;
@@ -161,6 +163,7 @@ public class FilingIndexPropertiesImpl implements FilingIndexProperties {
 
 		streamDiscoveryDelayMetric = requireNonNull(getEnv(STREAM_DISCOVERY_DELAY_METRIC, null));
 		streamEventsMetric = requireNonNull(getEnv(STREAM_EVENTS_METRIC, null));
+		streamReceivedEventsAgeMetric = requireNonNull(getEnv(STREAM_RECEIVED_EVENTS_AGE_METRIC, null));
 
 		supportEmail = getEnv(SUPPORT_EMAIL, null);
 
@@ -385,6 +388,10 @@ public class FilingIndexPropertiesImpl implements FilingIndexProperties {
 
 	public String streamEventsMetric() {
 		return streamEventsMetric;
+	}
+
+	public String streamReceivedEventsAgeMetric() {
+		return streamReceivedEventsAgeMetric;
 	}
 
 	public String supportEmail() {

--- a/src/main/resources/db/migration/V13__stream_discovered_date_index.sql
+++ b/src/main/resources/db/migration/V13__stream_discovered_date_index.sql
@@ -1,0 +1,2 @@
+-- select max(discovered_date) from filings where stream_timepoint is not null
+CREATE INDEX filings_stream_discovered_date_idx ON filings (discovered_date) WHERE stream_timepoint IS NOT NULL;

--- a/src/main/resources/db/migration/V14__stream_receipts.sql
+++ b/src/main/resources/db/migration/V14__stream_receipts.sql
@@ -1,0 +1,6 @@
+-- Survives the server task, so that the age of the last event received from the Companies House
+-- stream is not reset to zero by every deploy and every task replacement.
+CREATE TABLE stream_receipts (
+    id INT PRIMARY KEY DEFAULT 1 CHECK (id = 1),
+    last_received_date TIMESTAMPTZ NOT NULL
+);

--- a/src/test/java/com/frc/codex/clients/companieshouse/impl/CompaniesHouseStreamListenerImplTest.java
+++ b/src/test/java/com/frc/codex/clients/companieshouse/impl/CompaniesHouseStreamListenerImplTest.java
@@ -1,0 +1,134 @@
+package com.frc.codex.clients.companieshouse.impl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+import java.util.function.Function;
+import java.util.stream.IntStream;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.frc.codex.clients.companieshouse.CompaniesHouseClient;
+import com.frc.codex.database.DatabaseManager;
+
+@ExtendWith(MockitoExtension.class)
+public class CompaniesHouseStreamListenerImplTest {
+
+	@Mock
+	private CompaniesHouseClient companiesHouseClient;
+
+	@Mock
+	private DatabaseManager databaseManager;
+
+	private CompaniesHouseStreamListenerImpl listener;
+
+	@BeforeEach
+	public void setUp() {
+		listener = new CompaniesHouseStreamListenerImpl(companiesHouseClient, databaseManager);
+	}
+
+	@Test
+	public void postConstruct_resumesThePersistedReceiptDate() {
+		Instant persisted = Instant.parse("2026-08-03T09:00:00Z");
+		when(databaseManager.getLastStreamEventReceivedDate()).thenReturn(persisted);
+
+		listener.postConstruct();
+
+		assertEquals(persisted, listener.getLastEventReceivedDate());
+	}
+
+	@Test
+	public void postConstruct_seedsFromNowWhenNothingWasEverReceived() {
+		when(databaseManager.getLastStreamEventReceivedDate()).thenReturn(null);
+
+		listener.postConstruct();
+
+		Instant seeded = listener.getLastEventReceivedDate();
+		assertNotNull(seeded);
+		assertTrue(Duration.between(seeded, Instant.now()).toSeconds() < 60);
+	}
+
+	@Test
+	public void postConstruct_publishesNoAgeWhenTheRecordCannotBeRead() {
+		when(databaseManager.getLastStreamEventReceivedDate())
+				.thenThrow(new RuntimeException("database unavailable"));
+
+		listener.postConstruct();
+
+		assertNull(listener.getLastEventReceivedDate());
+		assertTrue(listener.getStatus().contains("Last event received: unknown"));
+	}
+
+	@Test
+	public void run_persistsTheFirstReceiptThenThrottles() throws Exception {
+		when(databaseManager.getLastStreamEventReceivedDate())
+				.thenReturn(Instant.now().minus(Duration.ofHours(1)));
+		listener.postConstruct();
+		streamEvents(2);
+
+		listener.run(() -> true);
+
+		verify(databaseManager, times(2)).createStreamEvent(any(Long.class), any(String.class));
+		verify(databaseManager, times(1)).updateLastStreamEventReceivedDate(any(Instant.class));
+	}
+
+	@Test
+	public void run_retriesTheWriteWhenItFails() throws Exception {
+		when(databaseManager.getLastStreamEventReceivedDate())
+				.thenReturn(Instant.now().minus(Duration.ofHours(1)));
+		listener.postConstruct();
+		doThrow(new RuntimeException("database unavailable"))
+				.when(databaseManager).updateLastStreamEventReceivedDate(any(Instant.class));
+		streamEvents(2);
+
+		listener.run(() -> true);
+
+		verify(databaseManager, times(2)).updateLastStreamEventReceivedDate(any(Instant.class));
+		assertNotNull(listener.getLastEventReceivedDate());
+	}
+
+	@Test
+	public void run_recordsNoReceiptForAnEventWithoutATimepoint() throws Exception {
+		when(databaseManager.getLastStreamEventReceivedDate())
+				.thenReturn(Instant.now().minus(Duration.ofHours(1)));
+		listener.postConstruct();
+		Instant seeded = listener.getLastEventReceivedDate();
+		streamJson(List.of("{\"resource_kind\":\"filing-history\"}"));
+
+		listener.run(() -> true);
+
+		verify(databaseManager, never()).createStreamEvent(any(Long.class), any(String.class));
+		verify(databaseManager, never()).updateLastStreamEventReceivedDate(any(Instant.class));
+		assertEquals(seeded, listener.getLastEventReceivedDate());
+	}
+
+	private void streamEvents(int count) throws Exception {
+		streamJson(IntStream.rangeClosed(1, count)
+				.mapToObj(i -> "{\"resource_kind\":\"filing-history\",\"event\":{\"timepoint\":%d}}".formatted(i))
+				.toList());
+	}
+
+	private void streamJson(List<String> events) throws Exception {
+		doAnswer(invocation -> {
+			Function<String, Boolean> callback = invocation.getArgument(1);
+			events.forEach(callback::apply);
+			return null;
+		}).when(companiesHouseClient).streamFilings(any(), any());
+	}
+}

--- a/src/test/java/com/frc/codex/database/impl/TestDatabaseManagerImpl.java
+++ b/src/test/java/com/frc/codex/database/impl/TestDatabaseManagerImpl.java
@@ -1,5 +1,6 @@
 package com.frc.codex.database.impl;
 
+import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -120,6 +121,12 @@ public class TestDatabaseManagerImpl implements DatabaseManager {
 	}
 
 	public void updateFilingStatus(UUID filingId, String status) { }
+
+	public Instant getLastStreamEventReceivedDate() {
+		return null;
+	}
+
+	public void updateLastStreamEventReceivedDate(Instant receivedDate) { }
 
 	public Set<String> getCompaniesCompanyNumbers() {
 		return Set.of();

--- a/src/test/java/com/frc/codex/database/impl/TestDatabaseManagerImpl.java
+++ b/src/test/java/com/frc/codex/database/impl/TestDatabaseManagerImpl.java
@@ -19,6 +19,7 @@ import com.frc.codex.model.FilingStatus;
 import com.frc.codex.model.NewFilingRequest;
 import com.frc.codex.model.SearchFilingsRequest;
 import com.frc.codex.model.StreamEvent;
+import com.frc.codex.model.StreamEventsStats;
 import com.frc.codex.model.companieshouse.CompaniesHouseArchive;
 
 @Component
@@ -110,8 +111,8 @@ public class TestDatabaseManagerImpl implements DatabaseManager {
 		return null;
 	}
 
-	public long getStreamEventsCount() {
-		return 0;
+	public StreamEventsStats getStreamEventsStats() {
+		return new StreamEventsStats(0, 0);
 	}
 
 	public void resetFiling(UUID filingId) { }

--- a/src/test/java/com/frc/codex/impl/TestFilingIndexPropertiesImpl.java
+++ b/src/test/java/com/frc/codex/impl/TestFilingIndexPropertiesImpl.java
@@ -174,6 +174,10 @@ public class TestFilingIndexPropertiesImpl implements FilingIndexProperties {
 		return null;
 	}
 
+	public String streamReceivedEventsAgeMetric() {
+		return null;
+	}
+
 	public String supportEmail() {
 		return null;
 	}

--- a/src/test/java/com/frc/codex/impl/TestFilingIndexPropertiesImpl.java
+++ b/src/test/java/com/frc/codex/impl/TestFilingIndexPropertiesImpl.java
@@ -170,6 +170,10 @@ public class TestFilingIndexPropertiesImpl implements FilingIndexProperties {
 		return null;
 	}
 
+	public String streamEventsHeadAgeMetric() {
+		return null;
+	}
+
 	public String streamEventsMetric() {
 		return null;
 	}


### PR DESCRIPTION
#### Reason for change

I'm currently diagnosing alarm triggers. This PR is primarily to add additional metrics to confirm issues.

Nothing counts events received from the CH stream, so a connected but silent stream reads as healthy, a six-day upstream outage went undetected for 138 hours. Separately, `uploadMetrics` runs at ~3x its configured delay on an unindexed `MAX(discovered_date)`.

#### Description of change

- V13: partial index on filings(discovered_date) for the discovery-delay query.
- V14 + new metric: age of the last event received from the stream, persisted so a deploy or task replacement doesn't reset it and report a false recovery.
- New metric: age of the oldest queued stream event.
- Metrics are collected per metric, so one failure no longer discards the whole upload.
- The indexer's Failed to handle CH filing stream event log now names the event.

Both new metrics are unalarmed. No existing threshold, metric or alarm changed.

#### Steps to Test

* [x] CI
* [x] deploy and test in dev env (including cloudformation update)

**review**:
@Arelle/arelle
