### PR TITLE
Pin the server deployment's bake time

### DIFF
--- a/deploy/cfn.yml
+++ b/deploy/cfn.yml
@@ -93,6 +93,10 @@ Parameters:
     Type: Number
     Default: 0
     Description: "Minutes a deployment waits after the new server task is healthy before it completes. Pinned so an AWS-side default cannot change deployment duration or the rollback window."
+  ServerHealthCheckGracePeriod:
+    Type: Number
+    Default: 0
+    Description: "Seconds a starting server task is exempt from load balancer health checks. Raise this for a deploy that is expected to run a database migration, to a value exceeding the migration's duration, then return it to 0."
   ServerStreamDiscoveryDelayAlarmThreshold:
     Type: Number
     Default: 28800
@@ -661,6 +665,7 @@ Resources:
         Type: ECS
       DesiredCount: 1
       EnableECSManagedTags: true
+      HealthCheckGracePeriodSeconds: !Ref ServerHealthCheckGracePeriod
       LoadBalancers:
         - ContainerName: server
           ContainerPort: 8080

--- a/deploy/cfn.yml
+++ b/deploy/cfn.yml
@@ -89,6 +89,10 @@ Parameters:
     Type: Number
     Default: 0
     Description: "The number of server errors to exceed before triggering alarm."
+  ServerDeploymentBakeTime:
+    Type: Number
+    Default: 0
+    Description: "Minutes a deployment waits after the new server task is healthy before it completes. Pinned so an AWS-side default cannot change deployment duration or the rollback window."
   ServerStreamDiscoveryDelayAlarmThreshold:
     Type: Number
     Default: 28800
@@ -647,6 +651,7 @@ Resources:
       ServiceName: server
       Cluster: !Ref ECSCluster
       DeploymentConfiguration:
+        BakeTimeInMinutes: !Ref ServerDeploymentBakeTime
         MaximumPercent: 200
         MinimumHealthyPercent: 100
         DeploymentCircuitBreaker:


### PR DESCRIPTION
#### Reason for change

Prod deployments went from 1m40s on 2026-07-21 to 17m04s on 2026-07-23 with no code
change: both ran v0.77, and task definitions 68 and 69 carry byte-identical container
config. `describe-service-deployments` shows the whole difference. The 07-21 deployment
has `bakeTimeInMinutes: 0`, the 07-23 one has 15, and 15m24s of the 15m24s gap is that
wait. 07-31 then took 17m03s -- within 0.3s of 07-23, the signature of a fixed wait
rather than anything load-dependent.

Nothing in this template set it. dev2 flipped from 0 to 15 in the same window with no
deployment in between (07-22 12:47 EDT bake 0, 07-23 09:15 EDT bake 15), so the value
changed on the services themselves, not through CloudFormation.

Also added `ServerHealthCheckGracePeriod` so expected DB migrations don't force rollbacks on deploy.

#### Description of change

0 restores the behavior every deployment before 07-23 had. Parameterized rather than literal so a bake can be introduced deliberately, per environment, without a code change.

#### Steps to Test

* [x] deploy and confirm deploy time drops from > 15 min back down to < 2 mins

**review**:
@Arelle/arelle
